### PR TITLE
Implement max and min functions

### DIFF
--- a/demos/node_express/public/vendor/twig.js
+++ b/demos/node_express/public/vendor/twig.js
@@ -1802,7 +1802,228 @@ var Twig = (function(Twig) {
         }
 
         return (isHalf ? value : Math.round(value)) / m;
-    }
+    };
+
+    Twig.lib.max = function max() {
+        //  discuss at: http://phpjs.org/functions/max/
+        // original by: Onno Marsman
+        //  revised by: Onno Marsman
+        // improved by: Jack
+        //        note: Long code cause we're aiming for maximum PHP compatibility
+        //   example 1: max(1, 3, 5, 6, 7);
+        //   returns 1: 7
+        //   example 2: max([2, 4, 5]);
+        //   returns 2: 5
+        //   example 3: max(0, 'hello');
+        //   returns 3: 0
+        //   example 4: max('hello', 0);
+        //   returns 4: 'hello'
+        //   example 5: max(-1, 'hello');
+        //   returns 5: 'hello'
+        //   example 6: max([2, 4, 8], [2, 5, 7]);
+        //   returns 6: [2, 5, 7]
+
+        var ar, retVal, i = 0,
+            n = 0,
+            argv = arguments,
+            argc = argv.length,
+            _obj2Array = function (obj) {
+                if (Object.prototype.toString.call(obj) === '[object Array]') {
+                    return obj;
+                } else {
+                    var ar = [];
+                    for (var i in obj) {
+                        if (obj.hasOwnProperty(i)) {
+                            ar.push(obj[i]);
+                        }
+                    }
+                    return ar;
+                }
+            }; //function _obj2Array
+        _compare = function (current, next) {
+            var i = 0,
+                n = 0,
+                tmp = 0,
+                nl = 0,
+                cl = 0;
+
+            if (current === next) {
+                return 0;
+            } else if (typeof current === 'object') {
+                if (typeof next === 'object') {
+                    current = _obj2Array(current);
+                    next = _obj2Array(next);
+                    cl = current.length;
+                    nl = next.length;
+                    if (nl > cl) {
+                        return 1;
+                    } else if (nl < cl) {
+                        return -1;
+                    }
+                    for (i = 0, n = cl; i < n; ++i) {
+                        tmp = _compare(current[i], next[i]);
+                        if (tmp == 1) {
+                            return 1;
+                        } else if (tmp == -1) {
+                            return -1;
+                        }
+                    }
+                    return 0;
+                }
+                return -1;
+            } else if (typeof next === 'object') {
+                return 1;
+            } else if (isNaN(next) && !isNaN(current)) {
+                if (current == 0) {
+                    return 0;
+                }
+                return (current < 0 ? 1 : -1);
+            } else if (isNaN(current) && !isNaN(next)) {
+                if (next == 0) {
+                    return 0;
+                }
+                return (next > 0 ? 1 : -1);
+            }
+
+            if (next == current) {
+                return 0;
+            }
+            return (next > current ? 1 : -1);
+        }; //function _compare
+        if (argc === 0) {
+            throw new Error('At least one value should be passed to max()');
+        } else if (argc === 1) {
+            if (typeof argv[0] === 'object') {
+                ar = _obj2Array(argv[0]);
+            } else {
+                throw new Error('Wrong parameter count for max()');
+            }
+            if (ar.length === 0) {
+                throw new Error('Array must contain at least one element for max()');
+            }
+        } else {
+            ar = argv;
+        }
+
+        retVal = ar[0];
+        for (i = 1, n = ar.length; i < n; ++i) {
+            if (_compare(retVal, ar[i]) == 1) {
+                retVal = ar[i];
+            }
+        }
+
+        return retVal;
+    };
+
+    Twig.lib.min = function min() {
+        //  discuss at: http://phpjs.org/functions/min/
+        // original by: Onno Marsman
+        //  revised by: Onno Marsman
+        // improved by: Jack
+        //        note: Long code cause we're aiming for maximum PHP compatibility
+        //   example 1: min(1, 3, 5, 6, 7);
+        //   returns 1: 1
+        //   example 2: min([2, 4, 5]);
+        //   returns 2: 2
+        //   example 3: min(0, 'hello');
+        //   returns 3: 0
+        //   example 4: min('hello', 0);
+        //   returns 4: 'hello'
+        //   example 5: min(-1, 'hello');
+        //   returns 5: -1
+        //   example 6: min([2, 4, 8], [2, 5, 7]);
+        //   returns 6: [2, 4, 8]
+
+        var ar, retVal, i = 0,
+            n = 0,
+            argv = arguments,
+            argc = argv.length,
+            _obj2Array = function (obj) {
+                if (Object.prototype.toString.call(obj) === '[object Array]') {
+                    return obj;
+                }
+                var ar = [];
+                for (var i in obj) {
+                    if (obj.hasOwnProperty(i)) {
+                        ar.push(obj[i]);
+                    }
+                }
+                return ar;
+            }; //function _obj2Array
+        _compare = function (current, next) {
+            var i = 0,
+                n = 0,
+                tmp = 0,
+                nl = 0,
+                cl = 0;
+
+            if (current === next) {
+                return 0;
+            } else if (typeof current === 'object') {
+                if (typeof next === 'object') {
+                    current = _obj2Array(current);
+                    next = _obj2Array(next);
+                    cl = current.length;
+                    nl = next.length;
+                    if (nl > cl) {
+                        return 1;
+                    } else if (nl < cl) {
+                        return -1;
+                    }
+                    for (i = 0, n = cl; i < n; ++i) {
+                        tmp = _compare(current[i], next[i]);
+                        if (tmp == 1) {
+                            return 1;
+                        } else if (tmp == -1) {
+                            return -1;
+                        }
+                    }
+                    return 0;
+                }
+                return -1;
+            } else if (typeof next === 'object') {
+                return 1;
+            } else if (isNaN(next) && !isNaN(current)) {
+                if (current == 0) {
+                    return 0;
+                }
+                return (current < 0 ? 1 : -1);
+            } else if (isNaN(current) && !isNaN(next)) {
+                if (next == 0) {
+                    return 0;
+                }
+                return (next > 0 ? 1 : -1);
+            }
+
+            if (next == current) {
+                return 0;
+            }
+            return (next > current ? 1 : -1);
+        }; //function _compare
+        if (argc === 0) {
+            throw new Error('At least one value should be passed to min()');
+        } else if (argc === 1) {
+            if (typeof argv[0] === 'object') {
+                ar = _obj2Array(argv[0]);
+            } else {
+                throw new Error('Wrong parameter count for min()');
+            }
+            if (ar.length === 0) {
+                throw new Error('Array must contain at least one element for min()');
+            }
+        } else {
+            ar = argv;
+        }
+
+        retVal = ar[0];
+        for (i = 1, n = ar.length; i < n; ++i) {
+            if (_compare(retVal, ar[i]) == -1) {
+                retVal = ar[i];
+            }
+        }
+
+        return retVal;
+    };
 
     return Twig;
 
@@ -4877,6 +5098,22 @@ var Twig = (function (Twig) {
             return new Twig.Template({
                 data: template
             });
+        },
+        max: function(values) {
+            if(Twig.lib.is("Object", values)) {
+                delete values["_keys"];
+                return Twig.lib.max(values);
+            }
+
+            return Twig.lib.max.apply(null, arguments);
+        },
+        min: function(values) {
+            if(Twig.lib.is("Object", values)) {
+                delete values["_keys"];
+                return Twig.lib.min(values);
+            }
+
+            return Twig.lib.min.apply(null, arguments);
         }
     };
 

--- a/demos/twitter_backbone/vendor/twig.js
+++ b/demos/twitter_backbone/vendor/twig.js
@@ -1802,7 +1802,228 @@ var Twig = (function(Twig) {
         }
 
         return (isHalf ? value : Math.round(value)) / m;
-    }
+    };
+
+    Twig.lib.max = function max() {
+        //  discuss at: http://phpjs.org/functions/max/
+        // original by: Onno Marsman
+        //  revised by: Onno Marsman
+        // improved by: Jack
+        //        note: Long code cause we're aiming for maximum PHP compatibility
+        //   example 1: max(1, 3, 5, 6, 7);
+        //   returns 1: 7
+        //   example 2: max([2, 4, 5]);
+        //   returns 2: 5
+        //   example 3: max(0, 'hello');
+        //   returns 3: 0
+        //   example 4: max('hello', 0);
+        //   returns 4: 'hello'
+        //   example 5: max(-1, 'hello');
+        //   returns 5: 'hello'
+        //   example 6: max([2, 4, 8], [2, 5, 7]);
+        //   returns 6: [2, 5, 7]
+
+        var ar, retVal, i = 0,
+            n = 0,
+            argv = arguments,
+            argc = argv.length,
+            _obj2Array = function (obj) {
+                if (Object.prototype.toString.call(obj) === '[object Array]') {
+                    return obj;
+                } else {
+                    var ar = [];
+                    for (var i in obj) {
+                        if (obj.hasOwnProperty(i)) {
+                            ar.push(obj[i]);
+                        }
+                    }
+                    return ar;
+                }
+            }; //function _obj2Array
+        _compare = function (current, next) {
+            var i = 0,
+                n = 0,
+                tmp = 0,
+                nl = 0,
+                cl = 0;
+
+            if (current === next) {
+                return 0;
+            } else if (typeof current === 'object') {
+                if (typeof next === 'object') {
+                    current = _obj2Array(current);
+                    next = _obj2Array(next);
+                    cl = current.length;
+                    nl = next.length;
+                    if (nl > cl) {
+                        return 1;
+                    } else if (nl < cl) {
+                        return -1;
+                    }
+                    for (i = 0, n = cl; i < n; ++i) {
+                        tmp = _compare(current[i], next[i]);
+                        if (tmp == 1) {
+                            return 1;
+                        } else if (tmp == -1) {
+                            return -1;
+                        }
+                    }
+                    return 0;
+                }
+                return -1;
+            } else if (typeof next === 'object') {
+                return 1;
+            } else if (isNaN(next) && !isNaN(current)) {
+                if (current == 0) {
+                    return 0;
+                }
+                return (current < 0 ? 1 : -1);
+            } else if (isNaN(current) && !isNaN(next)) {
+                if (next == 0) {
+                    return 0;
+                }
+                return (next > 0 ? 1 : -1);
+            }
+
+            if (next == current) {
+                return 0;
+            }
+            return (next > current ? 1 : -1);
+        }; //function _compare
+        if (argc === 0) {
+            throw new Error('At least one value should be passed to max()');
+        } else if (argc === 1) {
+            if (typeof argv[0] === 'object') {
+                ar = _obj2Array(argv[0]);
+            } else {
+                throw new Error('Wrong parameter count for max()');
+            }
+            if (ar.length === 0) {
+                throw new Error('Array must contain at least one element for max()');
+            }
+        } else {
+            ar = argv;
+        }
+
+        retVal = ar[0];
+        for (i = 1, n = ar.length; i < n; ++i) {
+            if (_compare(retVal, ar[i]) == 1) {
+                retVal = ar[i];
+            }
+        }
+
+        return retVal;
+    };
+
+    Twig.lib.min = function min() {
+        //  discuss at: http://phpjs.org/functions/min/
+        // original by: Onno Marsman
+        //  revised by: Onno Marsman
+        // improved by: Jack
+        //        note: Long code cause we're aiming for maximum PHP compatibility
+        //   example 1: min(1, 3, 5, 6, 7);
+        //   returns 1: 1
+        //   example 2: min([2, 4, 5]);
+        //   returns 2: 2
+        //   example 3: min(0, 'hello');
+        //   returns 3: 0
+        //   example 4: min('hello', 0);
+        //   returns 4: 'hello'
+        //   example 5: min(-1, 'hello');
+        //   returns 5: -1
+        //   example 6: min([2, 4, 8], [2, 5, 7]);
+        //   returns 6: [2, 4, 8]
+
+        var ar, retVal, i = 0,
+            n = 0,
+            argv = arguments,
+            argc = argv.length,
+            _obj2Array = function (obj) {
+                if (Object.prototype.toString.call(obj) === '[object Array]') {
+                    return obj;
+                }
+                var ar = [];
+                for (var i in obj) {
+                    if (obj.hasOwnProperty(i)) {
+                        ar.push(obj[i]);
+                    }
+                }
+                return ar;
+            }; //function _obj2Array
+        _compare = function (current, next) {
+            var i = 0,
+                n = 0,
+                tmp = 0,
+                nl = 0,
+                cl = 0;
+
+            if (current === next) {
+                return 0;
+            } else if (typeof current === 'object') {
+                if (typeof next === 'object') {
+                    current = _obj2Array(current);
+                    next = _obj2Array(next);
+                    cl = current.length;
+                    nl = next.length;
+                    if (nl > cl) {
+                        return 1;
+                    } else if (nl < cl) {
+                        return -1;
+                    }
+                    for (i = 0, n = cl; i < n; ++i) {
+                        tmp = _compare(current[i], next[i]);
+                        if (tmp == 1) {
+                            return 1;
+                        } else if (tmp == -1) {
+                            return -1;
+                        }
+                    }
+                    return 0;
+                }
+                return -1;
+            } else if (typeof next === 'object') {
+                return 1;
+            } else if (isNaN(next) && !isNaN(current)) {
+                if (current == 0) {
+                    return 0;
+                }
+                return (current < 0 ? 1 : -1);
+            } else if (isNaN(current) && !isNaN(next)) {
+                if (next == 0) {
+                    return 0;
+                }
+                return (next > 0 ? 1 : -1);
+            }
+
+            if (next == current) {
+                return 0;
+            }
+            return (next > current ? 1 : -1);
+        }; //function _compare
+        if (argc === 0) {
+            throw new Error('At least one value should be passed to min()');
+        } else if (argc === 1) {
+            if (typeof argv[0] === 'object') {
+                ar = _obj2Array(argv[0]);
+            } else {
+                throw new Error('Wrong parameter count for min()');
+            }
+            if (ar.length === 0) {
+                throw new Error('Array must contain at least one element for min()');
+            }
+        } else {
+            ar = argv;
+        }
+
+        retVal = ar[0];
+        for (i = 1, n = ar.length; i < n; ++i) {
+            if (_compare(retVal, ar[i]) == -1) {
+                retVal = ar[i];
+            }
+        }
+
+        return retVal;
+    };
 
     return Twig;
 
@@ -4877,6 +5098,22 @@ var Twig = (function (Twig) {
             return new Twig.Template({
                 data: template
             });
+        },
+        max: function(values) {
+            if(Twig.lib.is("Object", values)) {
+                delete values["_keys"];
+                return Twig.lib.max(values);
+            }
+
+            return Twig.lib.max.apply(null, arguments);
+        },
+        min: function(values) {
+            if(Twig.lib.is("Object", values)) {
+                delete values["_keys"];
+                return Twig.lib.min(values);
+            }
+
+            return Twig.lib.min.apply(null, arguments);
         }
     };
 

--- a/src/twig.functions.js
+++ b/src/twig.functions.js
@@ -170,6 +170,22 @@ var Twig = (function (Twig) {
             // Array will return element 0-index
             return object[method] || undefined;
         },
+        max: function(values) {
+            if(Twig.lib.is("Object", values)) {
+                delete values["_keys"];
+                return Twig.lib.max(values);
+            }
+
+            return Twig.lib.max.apply(null, arguments);
+        },
+        min: function(values) {
+            if(Twig.lib.is("Object", values)) {
+                delete values["_keys"];
+                return Twig.lib.min(values);
+            }
+
+            return Twig.lib.min.apply(null, arguments);
+        },
         template_from_string: function(template) {
             if (template === undefined) {
                 template = '';

--- a/src/twig.lib.js
+++ b/src/twig.lib.js
@@ -707,7 +707,228 @@ var Twig = (function(Twig) {
         }
 
         return (isHalf ? value : Math.round(value)) / m;
-    }
+    };
+
+    Twig.lib.max = function max() {
+        //  discuss at: http://phpjs.org/functions/max/
+        // original by: Onno Marsman
+        //  revised by: Onno Marsman
+        // improved by: Jack
+        //        note: Long code cause we're aiming for maximum PHP compatibility
+        //   example 1: max(1, 3, 5, 6, 7);
+        //   returns 1: 7
+        //   example 2: max([2, 4, 5]);
+        //   returns 2: 5
+        //   example 3: max(0, 'hello');
+        //   returns 3: 0
+        //   example 4: max('hello', 0);
+        //   returns 4: 'hello'
+        //   example 5: max(-1, 'hello');
+        //   returns 5: 'hello'
+        //   example 6: max([2, 4, 8], [2, 5, 7]);
+        //   returns 6: [2, 5, 7]
+
+        var ar, retVal, i = 0,
+            n = 0,
+            argv = arguments,
+            argc = argv.length,
+            _obj2Array = function (obj) {
+                if (Object.prototype.toString.call(obj) === '[object Array]') {
+                    return obj;
+                } else {
+                    var ar = [];
+                    for (var i in obj) {
+                        if (obj.hasOwnProperty(i)) {
+                            ar.push(obj[i]);
+                        }
+                    }
+                    return ar;
+                }
+            }; //function _obj2Array
+        _compare = function (current, next) {
+            var i = 0,
+                n = 0,
+                tmp = 0,
+                nl = 0,
+                cl = 0;
+
+            if (current === next) {
+                return 0;
+            } else if (typeof current === 'object') {
+                if (typeof next === 'object') {
+                    current = _obj2Array(current);
+                    next = _obj2Array(next);
+                    cl = current.length;
+                    nl = next.length;
+                    if (nl > cl) {
+                        return 1;
+                    } else if (nl < cl) {
+                        return -1;
+                    }
+                    for (i = 0, n = cl; i < n; ++i) {
+                        tmp = _compare(current[i], next[i]);
+                        if (tmp == 1) {
+                            return 1;
+                        } else if (tmp == -1) {
+                            return -1;
+                        }
+                    }
+                    return 0;
+                }
+                return -1;
+            } else if (typeof next === 'object') {
+                return 1;
+            } else if (isNaN(next) && !isNaN(current)) {
+                if (current == 0) {
+                    return 0;
+                }
+                return (current < 0 ? 1 : -1);
+            } else if (isNaN(current) && !isNaN(next)) {
+                if (next == 0) {
+                    return 0;
+                }
+                return (next > 0 ? 1 : -1);
+            }
+
+            if (next == current) {
+                return 0;
+            }
+            return (next > current ? 1 : -1);
+        }; //function _compare
+        if (argc === 0) {
+            throw new Error('At least one value should be passed to max()');
+        } else if (argc === 1) {
+            if (typeof argv[0] === 'object') {
+                ar = _obj2Array(argv[0]);
+            } else {
+                throw new Error('Wrong parameter count for max()');
+            }
+            if (ar.length === 0) {
+                throw new Error('Array must contain at least one element for max()');
+            }
+        } else {
+            ar = argv;
+        }
+
+        retVal = ar[0];
+        for (i = 1, n = ar.length; i < n; ++i) {
+            if (_compare(retVal, ar[i]) == 1) {
+                retVal = ar[i];
+            }
+        }
+
+        return retVal;
+    };
+
+    Twig.lib.min = function min() {
+        //  discuss at: http://phpjs.org/functions/min/
+        // original by: Onno Marsman
+        //  revised by: Onno Marsman
+        // improved by: Jack
+        //        note: Long code cause we're aiming for maximum PHP compatibility
+        //   example 1: min(1, 3, 5, 6, 7);
+        //   returns 1: 1
+        //   example 2: min([2, 4, 5]);
+        //   returns 2: 2
+        //   example 3: min(0, 'hello');
+        //   returns 3: 0
+        //   example 4: min('hello', 0);
+        //   returns 4: 'hello'
+        //   example 5: min(-1, 'hello');
+        //   returns 5: -1
+        //   example 6: min([2, 4, 8], [2, 5, 7]);
+        //   returns 6: [2, 4, 8]
+
+        var ar, retVal, i = 0,
+            n = 0,
+            argv = arguments,
+            argc = argv.length,
+            _obj2Array = function (obj) {
+                if (Object.prototype.toString.call(obj) === '[object Array]') {
+                    return obj;
+                }
+                var ar = [];
+                for (var i in obj) {
+                    if (obj.hasOwnProperty(i)) {
+                        ar.push(obj[i]);
+                    }
+                }
+                return ar;
+            }; //function _obj2Array
+        _compare = function (current, next) {
+            var i = 0,
+                n = 0,
+                tmp = 0,
+                nl = 0,
+                cl = 0;
+
+            if (current === next) {
+                return 0;
+            } else if (typeof current === 'object') {
+                if (typeof next === 'object') {
+                    current = _obj2Array(current);
+                    next = _obj2Array(next);
+                    cl = current.length;
+                    nl = next.length;
+                    if (nl > cl) {
+                        return 1;
+                    } else if (nl < cl) {
+                        return -1;
+                    }
+                    for (i = 0, n = cl; i < n; ++i) {
+                        tmp = _compare(current[i], next[i]);
+                        if (tmp == 1) {
+                            return 1;
+                        } else if (tmp == -1) {
+                            return -1;
+                        }
+                    }
+                    return 0;
+                }
+                return -1;
+            } else if (typeof next === 'object') {
+                return 1;
+            } else if (isNaN(next) && !isNaN(current)) {
+                if (current == 0) {
+                    return 0;
+                }
+                return (current < 0 ? 1 : -1);
+            } else if (isNaN(current) && !isNaN(next)) {
+                if (next == 0) {
+                    return 0;
+                }
+                return (next > 0 ? 1 : -1);
+            }
+
+            if (next == current) {
+                return 0;
+            }
+            return (next > current ? 1 : -1);
+        }; //function _compare
+        if (argc === 0) {
+            throw new Error('At least one value should be passed to min()');
+        } else if (argc === 1) {
+            if (typeof argv[0] === 'object') {
+                ar = _obj2Array(argv[0]);
+            } else {
+                throw new Error('Wrong parameter count for min()');
+            }
+            if (ar.length === 0) {
+                throw new Error('Array must contain at least one element for min()');
+            }
+        } else {
+            ar = argv;
+        }
+
+        retVal = ar[0];
+        for (i = 1, n = ar.length; i < n; ++i) {
+            if (_compare(retVal, ar[i]) == -1) {
+                retVal = ar[i];
+            }
+        }
+
+        return retVal;
+    };
 
     return Twig;
 

--- a/twig.js
+++ b/twig.js
@@ -1802,7 +1802,228 @@ var Twig = (function(Twig) {
         }
 
         return (isHalf ? value : Math.round(value)) / m;
-    }
+    };
+
+    Twig.lib.max = function max() {
+        //  discuss at: http://phpjs.org/functions/max/
+        // original by: Onno Marsman
+        //  revised by: Onno Marsman
+        // improved by: Jack
+        //        note: Long code cause we're aiming for maximum PHP compatibility
+        //   example 1: max(1, 3, 5, 6, 7);
+        //   returns 1: 7
+        //   example 2: max([2, 4, 5]);
+        //   returns 2: 5
+        //   example 3: max(0, 'hello');
+        //   returns 3: 0
+        //   example 4: max('hello', 0);
+        //   returns 4: 'hello'
+        //   example 5: max(-1, 'hello');
+        //   returns 5: 'hello'
+        //   example 6: max([2, 4, 8], [2, 5, 7]);
+        //   returns 6: [2, 5, 7]
+
+        var ar, retVal, i = 0,
+            n = 0,
+            argv = arguments,
+            argc = argv.length,
+            _obj2Array = function (obj) {
+                if (Object.prototype.toString.call(obj) === '[object Array]') {
+                    return obj;
+                } else {
+                    var ar = [];
+                    for (var i in obj) {
+                        if (obj.hasOwnProperty(i)) {
+                            ar.push(obj[i]);
+                        }
+                    }
+                    return ar;
+                }
+            }; //function _obj2Array
+        _compare = function (current, next) {
+            var i = 0,
+                n = 0,
+                tmp = 0,
+                nl = 0,
+                cl = 0;
+
+            if (current === next) {
+                return 0;
+            } else if (typeof current === 'object') {
+                if (typeof next === 'object') {
+                    current = _obj2Array(current);
+                    next = _obj2Array(next);
+                    cl = current.length;
+                    nl = next.length;
+                    if (nl > cl) {
+                        return 1;
+                    } else if (nl < cl) {
+                        return -1;
+                    }
+                    for (i = 0, n = cl; i < n; ++i) {
+                        tmp = _compare(current[i], next[i]);
+                        if (tmp == 1) {
+                            return 1;
+                        } else if (tmp == -1) {
+                            return -1;
+                        }
+                    }
+                    return 0;
+                }
+                return -1;
+            } else if (typeof next === 'object') {
+                return 1;
+            } else if (isNaN(next) && !isNaN(current)) {
+                if (current == 0) {
+                    return 0;
+                }
+                return (current < 0 ? 1 : -1);
+            } else if (isNaN(current) && !isNaN(next)) {
+                if (next == 0) {
+                    return 0;
+                }
+                return (next > 0 ? 1 : -1);
+            }
+
+            if (next == current) {
+                return 0;
+            }
+            return (next > current ? 1 : -1);
+        }; //function _compare
+        if (argc === 0) {
+            throw new Error('At least one value should be passed to max()');
+        } else if (argc === 1) {
+            if (typeof argv[0] === 'object') {
+                ar = _obj2Array(argv[0]);
+            } else {
+                throw new Error('Wrong parameter count for max()');
+            }
+            if (ar.length === 0) {
+                throw new Error('Array must contain at least one element for max()');
+            }
+        } else {
+            ar = argv;
+        }
+
+        retVal = ar[0];
+        for (i = 1, n = ar.length; i < n; ++i) {
+            if (_compare(retVal, ar[i]) == 1) {
+                retVal = ar[i];
+            }
+        }
+
+        return retVal;
+    };
+
+    Twig.lib.min = function min() {
+        //  discuss at: http://phpjs.org/functions/min/
+        // original by: Onno Marsman
+        //  revised by: Onno Marsman
+        // improved by: Jack
+        //        note: Long code cause we're aiming for maximum PHP compatibility
+        //   example 1: min(1, 3, 5, 6, 7);
+        //   returns 1: 1
+        //   example 2: min([2, 4, 5]);
+        //   returns 2: 2
+        //   example 3: min(0, 'hello');
+        //   returns 3: 0
+        //   example 4: min('hello', 0);
+        //   returns 4: 'hello'
+        //   example 5: min(-1, 'hello');
+        //   returns 5: -1
+        //   example 6: min([2, 4, 8], [2, 5, 7]);
+        //   returns 6: [2, 4, 8]
+
+        var ar, retVal, i = 0,
+            n = 0,
+            argv = arguments,
+            argc = argv.length,
+            _obj2Array = function (obj) {
+                if (Object.prototype.toString.call(obj) === '[object Array]') {
+                    return obj;
+                }
+                var ar = [];
+                for (var i in obj) {
+                    if (obj.hasOwnProperty(i)) {
+                        ar.push(obj[i]);
+                    }
+                }
+                return ar;
+            }; //function _obj2Array
+        _compare = function (current, next) {
+            var i = 0,
+                n = 0,
+                tmp = 0,
+                nl = 0,
+                cl = 0;
+
+            if (current === next) {
+                return 0;
+            } else if (typeof current === 'object') {
+                if (typeof next === 'object') {
+                    current = _obj2Array(current);
+                    next = _obj2Array(next);
+                    cl = current.length;
+                    nl = next.length;
+                    if (nl > cl) {
+                        return 1;
+                    } else if (nl < cl) {
+                        return -1;
+                    }
+                    for (i = 0, n = cl; i < n; ++i) {
+                        tmp = _compare(current[i], next[i]);
+                        if (tmp == 1) {
+                            return 1;
+                        } else if (tmp == -1) {
+                            return -1;
+                        }
+                    }
+                    return 0;
+                }
+                return -1;
+            } else if (typeof next === 'object') {
+                return 1;
+            } else if (isNaN(next) && !isNaN(current)) {
+                if (current == 0) {
+                    return 0;
+                }
+                return (current < 0 ? 1 : -1);
+            } else if (isNaN(current) && !isNaN(next)) {
+                if (next == 0) {
+                    return 0;
+                }
+                return (next > 0 ? 1 : -1);
+            }
+
+            if (next == current) {
+                return 0;
+            }
+            return (next > current ? 1 : -1);
+        }; //function _compare
+        if (argc === 0) {
+            throw new Error('At least one value should be passed to min()');
+        } else if (argc === 1) {
+            if (typeof argv[0] === 'object') {
+                ar = _obj2Array(argv[0]);
+            } else {
+                throw new Error('Wrong parameter count for min()');
+            }
+            if (ar.length === 0) {
+                throw new Error('Array must contain at least one element for min()');
+            }
+        } else {
+            ar = argv;
+        }
+
+        retVal = ar[0];
+        for (i = 1, n = ar.length; i < n; ++i) {
+            if (_compare(retVal, ar[i]) == -1) {
+                retVal = ar[i];
+            }
+        }
+
+        return retVal;
+    };
 
     return Twig;
 
@@ -4877,6 +5098,22 @@ var Twig = (function (Twig) {
             return new Twig.Template({
                 data: template
             });
+        },
+        max: function(values) {
+            if(Twig.lib.is("Object", values)) {
+                delete values["_keys"];
+                return Twig.lib.max(values);
+            }
+
+            return Twig.lib.max.apply(null, arguments);
+        },
+        min: function(values) {
+            if(Twig.lib.is("Object", values)) {
+                delete values["_keys"];
+                return Twig.lib.min(values);
+            }
+
+            return Twig.lib.min.apply(null, arguments);
         }
     };
 


### PR DESCRIPTION
**I'll preface this PR with this:**
The behavior of PHP's ``min`` and ``max`` functionals when passed associative arrays is ... *interesting*.

Regrettably, I've included the ``max`` and ``min`` functions from phpjs to ensure full compatibility. (The ``max`` and ``min`` functions are 90% similar and very long for what they do.)

There's much better ways to implement this using native ``Array.sort()`` and ``Math.max()`` and ``Math.min()``... however, the result doesn't behave as ``min`` and ``max``, so it won't pass the unit tests.

I didn't hack apart ``min`` and ``max`` to save a few bytes as gzip will take care of this. I would like to revisit any phpjs code we include to see if we can optimize some of the common code re-used between snippets.