### PR TITLE
Breaking test because of whitespace

### DIFF
--- a/test/templates/macro.twig
+++ b/test/templates/macro.twig
@@ -1,1 +1,2 @@
 {% macro echo(name) %}Hello {{ name }}{% endmacro %}
+{% macro whitespace_echo( name ) %}Hello {{ name }}{% endmacro %}

--- a/twig.js
+++ b/twig.js
@@ -2474,7 +2474,7 @@ var Twig = (function (Twig) {
              *
              */
             type: Twig.logic.type.macro,
-            regex: /^macro\s+([a-zA-Z0-9_]+)\s?\((([a-zA-Z0-9_]+(,\s?)?)*)\)$/,
+            regex: /^macro\s+([a-zA-Z0-9_]+)\s?\(\s?(([a-zA-Z0-9_]+(,\s?)?)*)\s?\)$/,
             next: [
                 Twig.logic.type.endmacro
             ],


### PR DESCRIPTION
Adding white space around the parameters of a macro will cause the parser to throw an exception. I believe this is a bug because it seems counter intuitive (white space mattering) and I didn't see any mention of significant white space in the twig documentation.

A work around would be removing the white space.

I've added a test which fails, I'm very sorry but at the moment I don't have the time to look in it and create a patch.