### PR TITLE
Allow int 0 as a key in objects

### DIFF
--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -229,7 +229,7 @@ var Twig = (function (Twig) {
                 }
             },
             parse: function(token, stack, context) {
-                if (token.key) {
+                if (token.key || token.key === 0) {
                     // handle ternary ':' operator
                     stack.push(token);
                 } else {
@@ -489,7 +489,7 @@ var Twig = (function (Twig) {
                         object_ended = true;
                         break;
                     }
-                    if (token && token.type && (token.type === Twig.expression.type.operator.binary || token.type === Twig.expression.type.operator.unary) && token.key) {
+                    if (token && token.type && (token.type === Twig.expression.type.operator.binary || token.type === Twig.expression.type.operator.unary) && (token.key || token.key === 0)) {
                         if (!has_value) {
                             throw new Twig.Error("Missing value for key '" + token.key + "' in object definition.");
                         }

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -109,6 +109,10 @@ describe("Twig.js Core ->", function() {
         twig({data: '{% set at = {"foo": null} %}{{ at.foo == val }}'}).render({val: null}).should.equal( "true" );
     });
 
+    it("should allow int 0 as a key in an object", function() {
+        twig({data: '{% set at = {0: "value"} %}{{ at.0 }}'}).render().should.equal( "value" );
+    });
+
     it("should support set capture", function() {
         twig({data: '{% set foo %}bar{% endset %}{{foo}}'}).render().should.equal( "bar" );
     });


### PR DESCRIPTION
This fails right now due to an incorrect truthy check.
I'm not sure if also allowing an empty string would be a good idea.