### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 0.6
   - 0.8
   - 0.10
   - 0.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
   - 0.8
   - 0.10
   - 0.11
+before_install:
+  - npm install -g npm@1.4


### PR DESCRIPTION
Hey.

Just noticed travis build started failing for this repo. And noticed it was because some of the dependencies started declaring dependencies with carets instead of tilde. So, just upgrading npm before the script starts fixes that.

Unfortunately newer npm does not work on node 0.6, so in this PR I also removed node 0.6 from the testing. I am guessing not many people use that anymore.

Thanks for making this and making it available, looking forward to playing more with it!

Have a nice day!