### PR TITLE
Fix `date` filter behavior

### DIFF
--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -230,10 +230,6 @@ var Twig = (function (Twig) {
             return obj;
         },
         date: function(value, params) {
-            if (value === undefined||value === null){
-                return;
-            }
-
             var date = Twig.functions.date(value);
             return Twig.lib.formatDate(date, params[0]);
         },

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -231,7 +231,8 @@ var Twig = (function (Twig) {
         },
         date: function(value, params) {
             var date = Twig.functions.date(value);
-            return Twig.lib.formatDate(date, params[0]);
+            var format = params && params.length ? params[0] : 'F j, Y H:i';
+            return Twig.lib.formatDate(date, format);
         },
 
         date_modify: function(value, params) {

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -243,7 +243,8 @@ describe("Twig.js Filters ->", function() {
 
         it("should handle undefined", function() {
             var test_template = twig({data: '{{ undef|date("d/m/Y @ H:i:s") }}' });
-            test_template.render().should.equal( "" );
+            var date = new Date();
+            test_template.render().should.equal(stringDate(date));
         });
     });
 

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -246,6 +246,11 @@ describe("Twig.js Filters ->", function() {
             var date = new Date();
             test_template.render().should.equal(stringDate(date));
         });
+
+        it("should work with no parameters", function() {
+            var test_template = twig({data: '{{ 27571323556|date }}' });
+            test_template.render().should.equal("September 13, 2843 15:59");
+        });
     });
 
     describe("replace ->", function() {


### PR DESCRIPTION
Makes `date` filter work correctly with an undefined value and an empty date format

Fixes #227