### PR TITLE
Allow expressions as keys in an object

### DIFF
--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -216,6 +216,8 @@ var Twig = (function (Twig) {
                                 key_token.type === Twig.expression.type.number) {
                             token.key = key_token.value;
 
+                        } else if (key_token.type === Twig.expression.type.parameter.end) {
+                            token.key_token = key_token;
                         } else {
                             throw new Twig.Error("Unexpected value before ':' of " + key_token.type + " = " + key_token.value);
                         }
@@ -228,6 +230,9 @@ var Twig = (function (Twig) {
                 }
             },
             parse: function(token, stack, context) {
+                if (token.key_token) {
+                    token.key = Twig.expression.parse.apply(this, [token.key_token, context])
+                }
                 if (token.key) {
                     // handle ternary ':' operator
                     stack.push(token);

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -116,6 +116,10 @@ describe("Twig.js Core ->", function() {
         twig({data: '{% set at = {"foo": null} %}{{ at.foo == val }}'}).render({val: null}).should.equal( "true" );
     });
 
+    it("should allow expressions as keys in an object", function() {
+        twig({data: '{{ {(1 + 1): 2}|json_encode() }}'}).render().should.equal( JSON.stringify({2: 2}) );
+    });
+
     it("should support set capture", function() {
         twig({data: '{% set foo %}bar{% endset %}{{foo}}'}).render().should.equal( "bar" );
     });


### PR DESCRIPTION
From the twig php docs:

>{# keys as expressions (the expression must be enclosed into parentheses) -- as of Twig 1.5 #}
>{ (1 + 1): 'foo', (a ~ 'b'): 'bar' }
