### PR TITLE
Twig.parse did not always return a string

### DIFF
--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -593,7 +593,7 @@ var Twig = (function (Twig) {
                         break;
                 }
             });
-            return Twig.output.apply(this, [output]);
+            return '' + Twig.output.apply(this, [output]);
         } catch (ex) {
             Twig.log.error("Error parsing twig template " + this.id + ": ");
             if (ex.stack) {


### PR DESCRIPTION
Because parse directly returns Twig.output which can return either a String
or a string you never know which of the two you will get.

I did try to write a test for it but I was unable to figure out how to do it properly with should.js

This is the code we use in our project in which we work around this problem

```js
class TwigService {

  constructor(twigValues) {
    this._twigValues = twigValues;
  }

  /**
   * @param id The identifier for the template
   * @param html The twig template to parse
   * @param values Values that are used in the twig template
   * @return string
   */
  render(id, html, values) {
    var twigTemplate = Twig.twig({ ref: id });
    if (twigTemplate === null) {
      twigTemplate = Twig.twig({
        id: id,
        data: html,
        autoescape: true,
        rethrow: true
      });
    }

    values = merge.recursive(true, values, this._twigValues);
    values.date = Math.round(Date.now() / 1000);

    // Render returns a String object instead of regular string
    // casting it explicitly to a string fixes this odd behaviour
    try {
      return '' + twigTemplate.render(values);
    } catch(e) {
      return 'An error occured while rendering: ' + e;
    }
  }
}
```