### PR TITLE
Support `undefined` and `null` values for the `in` operator

### DIFF
--- a/src/twig.expression.operator.js
+++ b/src/twig.expression.operator.js
@@ -17,10 +17,11 @@ var Twig = (function (Twig) {
     };
 
     var containment = function(a, b) {
-        if (b.indexOf !== undefined) {
+        if (b === undefined || b === null) {
+            return false;
+        } else if (b.indexOf !== undefined) {
             // String
             return a === b || a !== '' && b.indexOf(a) > -1;
-
         } else {
             var el;
             for (el in b) {


### PR DESCRIPTION
This code was failing:

```js
twig({
    data: '{{ 0 in undefined }} {{ 0 in null }}'
}).render();
```

Note that I wanted to add tests for this but I didn't found how to handle exceptions in your tests, this code never catches the exception:

```js
(function() {
    twig({
        data: '{{ 0 in undefined }} {{ 0 in null }}'
    }).render();
}).should.not.throw(TypeError);
```

Tried with the `expect` API but it doesn't work… You can either provide me instructions on how I should write those tests, or do it by yourself.