### PR TITLE
Add support for expressions as object keys

### DIFF
--- a/src/twig.expression.js
+++ b/src/twig.expression.js
@@ -215,7 +215,9 @@ var Twig = (function (Twig) {
                                 key_token.type === Twig.expression.type.variable ||
                                 key_token.type === Twig.expression.type.number) {
                             token.key = key_token.value;
-
+                        } else if (key_token.type === Twig.expression.type.parameter.end &&
+                                key_token.expression) {
+                            token.params = key_token.params;
                         } else {
                             throw new Twig.Error("Unexpected value before ':' of " + key_token.type + " = " + key_token.value);
                         }
@@ -231,6 +233,11 @@ var Twig = (function (Twig) {
                 if (token.key) {
                     // handle ternary ':' operator
                     stack.push(token);
+                } else if (token.params) {
+                    // handle "{(expression):value}"
+                    token.key = Twig.expression.parse.apply(this, [token.params, context]);
+                    stack.push(token);
+                    delete(token.params);
                 } else {
                     Twig.expression.operator.parse(token.value, stack);
                 }

--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -288,5 +288,14 @@ describe("Twig.js Expressions ->", function() {
             var test_template = twig({data: '{{ "d" not in {"key_a" : "no"} }}'});
             test_template.render().should.equal(true.toString());
         });
+
+        it("should support expressions as object keys", function() {
+            var test_template;
+            test_template = twig({data: '{% set a = {(foo): "value"} %}{{ a.bar }}'});
+            test_template.render({foo: 'bar'}).should.equal('value');
+
+            test_template = twig({data: '{{ {(foo): "value"}.bar }}'});
+            test_template.render({foo: 'bar'}).should.equal('value');
+        });
     });
 });


### PR DESCRIPTION
Adds an ability to use expressions as object keys:
```twig
{% set a = {foo: "bar"} %}
{% set b = {(a.foo): "value"} %}
{{ b.bar }}
```
will output `value`.

See http://twig.sensiolabs.org/doc/templates.html#literals:
> New in version 1.5: Support for hash keys as names and expressions was added in Twig 1.5.