### PR TITLE
Filter 'escape': support strategy parameter

### DIFF
--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -142,7 +142,9 @@ var Twig = (function (Twig) {
                 return;
             }
 
-            return encodeURIComponent(value);
+            var result = encodeURIComponent(value);
+            result = result.replace("'", "%27");
+            return result;
         },
         join: function(value, params) {
             if (value === undefined || value === null){

--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -341,21 +341,91 @@ var Twig = (function (Twig) {
             return Twig.lib.strip_tags(value);
         },
 
-        escape: function(value) {
+        escape: function(value, params) {
             if (value === undefined|| value === null){
                 return;
             }
-            var raw_value = value.toString().replace(/&/g, "&amp;")
-                        .replace(/</g, "&lt;")
-                        .replace(/>/g, "&gt;")
-                        .replace(/"/g, "&quot;")
-                        .replace(/'/g, "&#039;");
-            return Twig.Markup(raw_value);
+
+            var strategy = "html";
+            if(params && params.length)
+                strategy = params[0];
+
+            if(strategy == "html") {
+                var raw_value = value.toString().replace(/&/g, "&amp;")
+                            .replace(/</g, "&lt;")
+                            .replace(/>/g, "&gt;")
+                            .replace(/"/g, "&quot;")
+                            .replace(/'/g, "&#039;");
+                return Twig.Markup(raw_value);
+            } else if(strategy == "js") {
+                var raw_value = value.toString();
+                var result = "";
+
+                for(var i = 0; i < raw_value.length; i++) {
+                    if(raw_value[i].match(/^[a-zA-Z0-9,\._]$/))
+                        result += raw_value[i];
+                    else {
+                        var char_code = raw_value.charCodeAt(i);
+
+                        if(char_code < 0x80)
+                            result += "\\x" + char_code.toString(16).toUpperCase();
+                        else
+                            result += Twig.lib.sprintf("\\u%04s", char_code.toString(16).toUpperCase());
+                    }
+                }
+
+                return result;
+            } else if(strategy == "css") {
+                var raw_value = value.toString();
+                var result = "";
+
+                for(var i = 0; i < raw_value.length; i++) {
+                    if(raw_value[i].match(/^[a-zA-Z0-9]$/))
+                        result += raw_value[i];
+                    else {
+                        var char_code = raw_value.charCodeAt(i);
+                        result += "\\" + char_code.toString(16).toUpperCase() + " ";
+                    }
+                }
+
+                return result;
+            } else if(strategy == "url") {
+                return Twig.filters.url_encode(value);
+            } else if(strategy == "html_attr") {
+                var raw_value = value.toString();
+                var result = "";
+
+                for(var i = 0; i < raw_value.length; i++) {
+                    if(raw_value[i].match(/^[a-zA-Z0-9,\.\-_]$/))
+                        result += raw_value[i];
+                    else if(raw_value[i].match(/^[&<>"]$/))
+                        result += raw_value[i].replace(/&/g, "&amp;")
+                                .replace(/</g, "&lt;")
+                                .replace(/>/g, "&gt;")
+                                .replace(/"/g, "&quot;");
+                    else {
+                        var char_code = raw_value.charCodeAt(i);
+
+                        // The following replaces characters undefined in HTML with
+                        // the hex entity for the Unicode replacement character.
+                        if(char_code <= 0x1f && char_code != 0x09 && char_code != 0x0a && char_code != 0x0d)
+                            result += "&#xFFFD;";
+                        else if(char_code < 0x80)
+                            result += Twig.lib.sprintf("&#x%02s;", char_code.toString(16).toUpperCase());
+                        else
+                            result += Twig.lib.sprintf("&#x%04s;", char_code.toString(16).toUpperCase());
+                    }
+                }
+
+                return result;
+            } else {
+                throw new Twig.Error("escape strategy unsupported");
+            }
         },
 
         /* Alias of escape */
-        "e": function(value) {
-            return Twig.filters.escape(value);
+        "e": function(value, params) {
+            return Twig.filters.escape(value, params);
         },
 
         nl2br: function(value) {

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -352,6 +352,28 @@ describe("Twig.js Filters ->", function() {
                 value: "<test>&</test>"
             }).should.equal('&lt;test&gt;&amp;&lt;/test&gt;');
         });
+
+        it("should handle the strategy parameter", function() {
+            var data = { "foo": "<foo> \\&\"'.,-_?/Ķä€台北[]{}\t\r\n\b\x80" };
+
+            var test_template = twig({data: 'Default: {{ foo|escape }}' });
+            test_template.render(data).should.equal("Default: &lt;foo&gt; \\&amp;&quot;&#039;.,-_?/Ķä€台北[]{}\t\r\n\b\x80" );
+
+            var test_template = twig({data: 'html: {{ foo|escape("html") }}' });
+            test_template.render(data).should.equal("html: &lt;foo&gt; \\&amp;&quot;&#039;.,-_?/Ķä€台北[]{}\t\r\n\b\x80" );
+
+            var test_template = twig({data: 'js: {{ foo|escape("js") }}' });
+            test_template.render(data).should.equal("js: \\x3Cfoo\\x3E\\x20\\x5C\\x26\\x22\\x27.,\\x2D_\\x3F\\x2F\\u0136\\u00E4\\u20AC\\u53F0\\u5317\\x5B\\x5D\\x7B\\x7D\\x9\\xD\\xA\\x8\\u0080" );
+
+            var test_template = twig({data: 'css: {{ foo|escape("css") }}' });
+            test_template.render(data).should.equal("css: \\3C foo\\3E \\20 \\5C \\26 \\22 \\27 \\2E \\2C \\2D \\5F \\3F \\2F \\136 \\E4 \\20AC \\53F0 \\5317 \\5B \\5D \\7B \\7D \\9 \\D \\A \\8 \\80 " );
+
+            var test_template = twig({data: 'url: {{ foo|escape("url") }}' });
+            test_template.render(data).should.equal("url: %3Cfoo%3E%20%5C%26%22%27.%2C-_%3F%2F%C4%B6%C3%A4%E2%82%AC%E5%8F%B0%E5%8C%97%5B%5D%7B%7D%09%0D%0A%08%C2%80" );
+
+            var test_template = twig({data: 'html_attr: {{ foo|escape("html_attr") }}' });
+            test_template.render(data).should.equal("html_attr: &lt;foo&gt;&#x20;&#x5C;&amp;&quot;&#x27;.,-_&#x3F;&#x2F;&#x0136;&#x00E4;&#x20AC;&#x53F0;&#x5317;&#x5B;&#x5D;&#x7B;&#x7D;&#x09;&#x0D;&#x0A;&#xFFFD;&#x0080;" );
+        });
     });
 
     describe("e ->", function() {

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -12,6 +12,11 @@ describe("Twig.js Filters ->", function() {
             var test_template = twig({data: '{{ undef|url_encode() }}' });
             test_template.render().should.equal("" );
         });
+        it("should handle special characters", function() {
+            var data = { "foo": "<foo> \\&\"'.,-_?/Ķä€台北[]{}\t\r\n\b\x80" };
+            var test_template = twig({data: '{{ foo|url_encode() }}' });
+            test_template.render(data).should.equal("%3Cfoo%3E%20%5C%26%22%27.%2C-_%3F%2F%C4%B6%C3%A4%E2%82%AC%E5%8F%B0%E5%8C%97%5B%5D%7B%7D%09%0D%0A%08%C2%80" );
+        });
     });
     describe("json_encode ->", function() {
         it("should encode strings to json", function() {

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -374,6 +374,16 @@ describe("Twig.js Filters ->", function() {
             var test_template = twig({data: 'html_attr: {{ foo|escape("html_attr") }}' });
             test_template.render(data).should.equal("html_attr: &lt;foo&gt;&#x20;&#x5C;&amp;&quot;&#x27;.,-_&#x3F;&#x2F;&#x0136;&#x00E4;&#x20AC;&#x53F0;&#x5317;&#x5B;&#x5D;&#x7B;&#x7D;&#x09;&#x0D;&#x0A;&#xFFFD;&#x0080;" );
         });
+
+        it("should escape strategy != 'html' if autoescape is on", function() {
+            twig({
+                autoescape: true,
+                data: '{{ value|escape("js") }}'
+            }).render({
+                value: "<test>&</test>"
+            }).should.equal('\\x3Ctest\\x3E\\x26\\x3C\\x2Ftest\\x3E');
+        });
+
     });
 
     describe("e ->", function() {


### PR DESCRIPTION
Implement the following strategies:
* html: (default, already implemented)
* js
* css
* url
* html_attr

The pull request also includes the commit of pull request #288 , as this filter is used for the strategy 'url'.