### PR TITLE
 Allow default filter to take 0 parameters

### DIFF
--- a/src/twig.filters.js
+++ b/src/twig.filters.js
@@ -172,10 +172,14 @@ var Twig = (function (Twig) {
             return output.join(join_str);
         },
         "default": function(value, params) {
-            if (params === undefined || params.length !== 1) {
+            if (params !== undefined && params.length > 1) {
                 throw new Twig.Error("default filter expects one argument");
             }
             if (value === undefined || value === null || value === '' ) {
+                if (params === undefined) {
+                    return '';
+                }
+
                 return params[0];
             } else {
                 return value;

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -232,6 +232,19 @@ describe("Twig.js Filters ->", function() {
             test_template = twig({data: '{{ var.key|default("Empty Key") }}' });
             test_template.render({'var':{}}).should.equal("Empty Key" );
         });
+
+        it("should provide a default value of '' if no parameters are passed and a default key is not defined", function () {
+            var test_template = twig({data: '{{ var|default }}' });
+            test_template.render().should.equal("");
+        });
+
+        it("should provide a default value of '' if no parameters are passed and a value is empty", function () {
+            var test_template = twig({data: '{{ ""|default }}' });
+            test_template.render().should.equal("");
+
+            test_template = twig({data: '{{ var.key|default }}' });
+            test_template.render({'var':{}}).should.equal("");
+        });
     });
 
     describe("date ->", function() {


### PR DESCRIPTION
The PHP version of Twig allows default to be called without passing
any parameters, for example "{{ var|default|raw }}", with default
returning an empty string in this use case.

https://github.com/fabpot/Twig/blob/master/lib/Twig/Node/Expression/Filter/Default.php#L29