### PR TITLE
Filter 'date': recognise unix timestamps, when passed as string

### DIFF
--- a/src/twig.functions.js
+++ b/src/twig.functions.js
@@ -139,7 +139,12 @@ var Twig = (function (Twig) {
             } else if (Twig.lib.is("Date", date)) {
                 dateObj = date;
             } else if (Twig.lib.is("String", date)) {
-                dateObj = new Date(Twig.lib.strtotime(date) * 1000);
+                if (date.match(/^[0-9]+$/)) {
+                    dateObj = new Date(date * 1000);
+                }
+                else {
+                    dateObj = new Date(Twig.lib.strtotime(date) * 1000);
+                }
             } else if (Twig.lib.is("Number", date)) {
                 // timestamp
                 dateObj = new Date(date * 1000);

--- a/test/test.filters.js
+++ b/test/test.filters.js
@@ -261,6 +261,12 @@ describe("Twig.js Filters ->", function() {
 
             template.render().should.equal( stringDate(date) );
         });
+        it("should recognize timestamps, when they are passed as string", function() {
+            var template = twig({data: '{{ "27571323556"|date("d/m/Y @ H:i:s") }}'})
+                , date = new Date(27571323556000); // 13/09/2843 @ 08:59:16 EST
+
+            template.render().should.equal( stringDate(date) );
+        });
         it("should recognize string date formats", function() {
             var template = twig({data: '{{ "Tue Aug 14 08:52:15 +0000 2007"|date("d/m/Y @ H:i:s") }}'})
                 , date = new Date(1187081535000); // 14/08/2007 @ 04:52:15 EST


### PR DESCRIPTION
- fixes #296