### PR TITLE
Override template loading mechanism (Issue 294)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SRC = src/twig.header.js src/twig.core.js src/twig.fills.js src/twig.lib.js src/twig.logic.js src/twig.expression.js src/twig.expression.operator.js src/twig.filters.js src/twig.functions.js src/twig.tests.js src/twig.exports.js src/twig.compiler.js src/twig.module.js
+SRC = src/twig.header.js src/twig.core.js src/twig.loader.*.js src/twig.fills.js src/twig.lib.js src/twig.logic.js src/twig.expression.js src/twig.expression.operator.js src/twig.filters.js src/twig.functions.js src/twig.tests.js src/twig.exports.js src/twig.compiler.js src/twig.module.js
 
 TESTS = test/*.js
 TESTSEXT = test-ext/*.js

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -848,6 +848,16 @@ var Twig = (function (Twig) {
 
     // Namespace for template storage and retrieval
     Twig.Templates = {
+        /**
+         * Registered template loaders - use Twig.Templates.registerLoader to add supported loaders
+         * @type {Object}
+         */
+        loaders: {},
+
+        /**
+         * Cached / loaded templates
+         * @type {Object}
+         */
         registry: {}
     };
 
@@ -867,6 +877,65 @@ var Twig = (function (Twig) {
         }
         return true;
     }
+
+    /**
+     * Register a template loader
+     *
+     * @example
+     * Twig.extend(function(Twig) {
+     *    Twig.Templates.registerLoader('custom_loader', function(location, params, callback, error_callback) {
+     *        // ... load the template ...
+     *        params.data = loadedTemplateData;
+     *        // create and return the template
+     *        var template = new Twig.Template(params);
+     *        if (typeof callback === 'function') {
+     *            callback(template);
+     *        }
+     *        return template;
+     *    });
+     * });
+     * 
+     * @param {String} method_name The method this loader is intended for (ajax, fs)
+     * @param {Function} func The function to execute when loading the template
+     * @param {Object|undefined} scope Optional scope parameter to bind func to
+     *
+     * @throws Twig.Error
+     *
+     * @return {void}
+     */
+    Twig.Templates.registerLoader = function(method_name, func, scope) {
+        if (typeof func !== 'function') {
+            throw new Twig.Error('Unable to add loader for ' + method_name + ': Invalid function reference given.');
+        }
+        if (scope) {
+            func = func.bind(scope);
+        }
+        this.loaders[method_name] = func;
+    };
+
+    /**
+     * Remove a registered loader
+     * 
+     * @param {String} method_name The method name for the loader you wish to remove
+     *
+     * @return {void}
+     */
+    Twig.Templates.unRegisterLoader = function(method_name) {
+        if (this.isRegisteredLoader(method_name)) {
+            delete this.loaders[method_name];
+        }
+    };
+
+    /**
+     * See if a loader is registered by its method name
+     * 
+     * @param {String} method_name The name of the loader you are looking for
+     *
+     * @return {boolean}
+     */
+    Twig.Templates.isRegisteredLoader = function(method_name) {
+        return this.loaders.hasOwnProperty(method_name);
+    };
 
     /**
      * Save a template object to the store.
@@ -913,119 +982,31 @@ var Twig = (function (Twig) {
      *
      */
     Twig.Templates.loadRemote = function(location, params, callback, error_callback) {
-        var id          = params.id,
-            method      = params.method,
-            async       = params.async,
-            precompiled = params.precompiled,
-            template    = null;
+        var loader;
 
         // Default to async
-        if (async === undefined) async = true;
+        if (params.async === undefined) {
+            params.async = true;
+        }
 
         // Default to the URL so the template is cached.
-        if (id === undefined) {
-            id = location;
+        if (params.id === undefined) {
+            params.id = location;
         }
-        params.id = id;
 
         // Check for existing template
-        if (Twig.cache && Twig.Templates.registry.hasOwnProperty(id)) {
+        if (Twig.cache && Twig.Templates.registry.hasOwnProperty(params.id)) {
             // A template is already saved with the given id.
-            if (callback) {
-                callback(Twig.Templates.registry[id]);
+            if (typeof callback === 'function') {
+                callback(Twig.Templates.registry[params.id]);
             }
-            return Twig.Templates.registry[id];
+            // TODO: if async, return deferred promise
+            return Twig.Templates.registry[params.id];
         }
 
-        if (method == 'ajax') {
-            if (typeof XMLHttpRequest == "undefined") {
-                throw new Twig.Error("Unsupported platform: Unable to do remote requests " +
-                                     "because there is no XMLHTTPRequest implementation");
-            }
-
-            var xmlhttp = new XMLHttpRequest();
-            xmlhttp.onreadystatechange = function() {
-                var data = null;
-
-                if(xmlhttp.readyState == 4) {
-                    if (xmlhttp.status == 200 || (window.cordova && xmlhttp.status == 0)) {
-                        Twig.log.debug("Got template ", xmlhttp.responseText);
-
-                        if (precompiled === true) {
-                            data = JSON.parse(xmlhttp.responseText);
-                        } else {
-                            data = xmlhttp.responseText;
-                        }
-
-                        params.url = location;
-                        params.data = data;
-
-                        template = new Twig.Template(params);
-
-                        if (callback) {
-                            callback(template);
-                        }
-                    } else {
-                        if (error_callback) {
-                            error_callback(xmlhttp);
-                        }
-                    }
-                }
-            };
-            xmlhttp.open("GET", location, async);
-            xmlhttp.send();
-
-        } else { // if method = 'fs'
-            // Create local scope
-            (function() {
-                var fs = require('fs'),
-                    path = require('path'),
-                    data = null,
-                    loadTemplateFn = function(err, data) {
-                        if (err) {
-                            if (error_callback) {
-                                error_callback(err);
-                            }
-                            return;
-                        }
-
-                        if (precompiled === true) {
-                            data = JSON.parse(data);
-                        }
-
-                        params.data = data;
-                        params.path = location;
-
-                        // template is in data
-                        template = new Twig.Template(params);
-
-                        if (callback) {
-                            callback(template);
-                        }
-                    };
-
-                if (async === true) {
-                    fs.stat(location, function (err, stats) {
-                        if (err || !stats.isFile())
-                            throw new Twig.Error("Unable to find template file " + location);
-
-                        fs.readFile(location, 'utf8', loadTemplateFn);
-                    });
-                } else {
-                    if (!fs.statSync(location).isFile())
-                        throw new Twig.Error("Unable to find template file " + location);
-
-                    data = fs.readFileSync(location, 'utf8');
-                    loadTemplateFn(undefined, data);
-                }
-            })();
-        }
-        if (async === false) {
-            return template;
-        } else {
-            // placeholder for now, should eventually return a deferred object.
-            return true;
-        }
+        // Assume 'fs' if the loader is not defined
+        loader = this.loaders[params.method] || this.loaders.fs;
+        return loader.apply(null, arguments);
     };
 
     // Determine object type
@@ -1259,36 +1240,6 @@ var Twig = (function (Twig) {
         }
         return content;
     };
-
-    /**
-     * Generate the canonical version of a url based on the given base path and file path and in
-     * the previously registered namespaces.
-     *
-     * @param  {string} template The Twig Template
-     * @param  {string} file     The file path, may be relative and may contain namespaces.
-     *
-     * @return {string}          The canonical version of the path
-     */
-    function parsePath(template, file) {
-        var namespaces = null;
-
-        if (typeof template === 'object' && typeof template.options === 'object') {
-            namespaces = template.options.namespaces;
-        }
-
-        if (typeof namespaces === 'object' && file.indexOf('::') > 0) {
-            for (var k in namespaces){
-                if (namespaces.hasOwnProperty(k)) {
-                    file = file.replace(k + '::', namespaces[k]);
-                }
-            }
-
-            return file;
-        }
-
-        return relativePath(template, file);
-    }
-
 
     /**
      * Generate the canonical version of a url based on the given base path and file path and in

--- a/src/twig.exports.js
+++ b/src/twig.exports.js
@@ -61,7 +61,7 @@ var Twig = (function (Twig) {
             if (!Twig.Templates.isRegisteredLoader(params.method)) {
                 throw new Twig.Error('Loader for "' + params.method + '" is not defined.');
             }
-            return Twig.Templates.loadRemote(params.href || params.path || undefined, {
+            return Twig.Templates.loadRemote(params.name || params.href || params.path || id || undefined, {
                 id: id,
                 method: params.method,
                 base: params.base,

--- a/src/twig.exports.js
+++ b/src/twig.exports.js
@@ -56,6 +56,21 @@ var Twig = (function (Twig) {
                 throw new Twig.Error("Both ref and id cannot be set on a twig.js template.");
             }
             return Twig.Templates.load(params.ref);
+        
+        } else if (params.method !== undefined) {
+            if (!Twig.Templates.isRegisteredLoader(params.method)) {
+                throw new Twig.Error('Loader for "' + params.method + '" is not defined.');
+            }
+            return Twig.Templates.loadRemote(params.href || params.path || undefined, {
+                id: id,
+                method: params.method,
+                base: params.base,
+                module: params.module,
+                precompiled: params.precompiled,
+                async: params.async,
+                options: options
+
+            }, params.load, params.error);
 
         } else if (params.href !== undefined) {
             return Twig.Templates.loadRemote(params.href, {

--- a/src/twig.loader.ajax.js
+++ b/src/twig.loader.ajax.js
@@ -1,0 +1,55 @@
+(function(Twig) {
+
+    'use strict';
+
+    Twig.Templates.registerLoader('ajax', function(location, params, callback, error_callback) {
+        var template,
+            xmlhttp,
+            precompiled = params.precompiled;
+
+        if (typeof XMLHttpRequest === "undefined") {
+            throw new Twig.Error('Unsupported platform: Unable to do ajax requests ' +
+                                 'because there is no "XMLHTTPRequest" implementation');
+        }
+
+        xmlhttp = new XMLHttpRequest();
+        xmlhttp.onreadystatechange = function() {
+            var data = null;
+
+            if(xmlhttp.readyState === 4) {
+                if (xmlhttp.status === 200 || (window.cordova && xmlhttp.status == 0)) {
+                    Twig.log.debug("Got template ", xmlhttp.responseText);
+
+                    if (precompiled === true) {
+                        data = JSON.parse(xmlhttp.responseText);
+                    } else {
+                        data = xmlhttp.responseText;
+                    }
+
+                    params.url = location;
+                    params.data = data;
+
+                    template = new Twig.Template(params);
+
+                    if (typeof callback === 'function') {
+                        callback(template);
+                    }
+                } else {
+                    if (typeof error_callback === 'function') {
+                        error_callback(xmlhttp);
+                    }
+                }
+            }
+        };
+        xmlhttp.open("GET", location, !!params.async);
+        xmlhttp.send();
+
+        if (params.async) {
+            // TODO: return deferred promise
+            return true;
+        } else {
+            return template;
+        }
+    });
+
+}(Twig));

--- a/src/twig.loader.fs.js
+++ b/src/twig.loader.fs.js
@@ -1,0 +1,66 @@
+(function(Twig) {
+    'use strict';
+
+    var fs, path;
+
+    try {
+    	// require lib dependencies at runtime
+    	fs = require('fs');
+    	path = require('path');
+    } catch (e) {
+    	// NOTE: this is in a try/catch to avoid errors cross platform
+    }
+
+    Twig.Templates.registerLoader('fs', function(location, params, callback, error_callback) {
+        var template,
+            data = null,
+            precompiled = params.precompiled;
+
+        if (!fs || !path) {
+            throw new Twig.Error('Unsupported platform: Unable to load from file ' +
+                                 'because there is no "fs" or "path" implementation');
+        }
+
+        var loadTemplateFn = function(err, data) {
+            if (err) {
+                if (typeof error_callback === 'function') {
+                    error_callback(err);
+                }
+                return;
+            }
+
+            if (precompiled === true) {
+                data = JSON.parse(data);
+            }
+
+            params.data = data;
+            params.path = location;
+
+            // template is in data
+            template = new Twig.Template(params);
+
+            if (typeof callback === 'function') {
+                callback(template);
+            }
+        };
+
+        if (params.async) {
+            fs.stat(location, function (err, stats) {
+                if (err || !stats.isFile()) {
+                    throw new Twig.Error('Unable to find template file ' + location);
+                }
+                fs.readFile(location, 'utf8', loadTemplateFn);
+            });
+            // TODO: return deferred promise
+            return true;
+        } else {
+            if (!fs.statSync(location).isFile()) {
+                throw new Twig.Error('Unable to find template file ' + location);
+            }
+            data = fs.readFileSync(location, 'utf8');
+            loadTemplateFn(undefined, data);
+            return template
+        }
+    });
+
+}(Twig));

--- a/test/index.html
+++ b/test/index.html
@@ -21,6 +21,7 @@
   <script src="test.regression.js"></script>
   <script src="test.tags.js"></script>
   <script src="test.tests.js"></script>
+  <script src="test.loaders.js"></script>
   <script src="browser/test.browser.js"></script>
   <script src="browser/test.block.js"></script>
   <script src="browser/test.macro.js"></script>

--- a/test/test.loaders.js
+++ b/test/test.loaders.js
@@ -7,9 +7,15 @@ describe("Twig.js Loaders ->", function() {
         it("should define a custom loader", function() {
             Twig.extend(function(Twig) {
                 var obj = {
-                    test: 'with scope',
+                    templates: {
+                        'custom_loader_block': '{% block main %}This lets you {% block data %}use blocks{% endblock data %}{% endblock main %}',
+                        'custom_loader_simple': 'the value is: {{ value }}',
+                        'custom_loader_include': 'include others from the same loader method - {% include "custom_loader_simple" %}',
+                        'custom_loader_complex': '{% extends "custom_loader_block" %} {% block data %}extend other templates and {% include "custom_loader_include" %}{% endblock data %}'
+                    },
                     loader: function(location, params, callback, error_callback) {
-                        params.data = 'the value is: {{ value }} - ' + this.test;
+                        params.data = this.templates[location];
+                        params.allowInlineIncludes = true;
                         var template = new Twig.Template(params);
                         if (typeof callback === 'function') {
                             callback(template);
@@ -21,9 +27,23 @@ describe("Twig.js Loaders ->", function() {
                 Twig.Templates.loaders.should.have.property('custom');
             });
         });
-        it("should load a template from a custom loader", function() {
-            var test_template = twig({method: 'custom'});
-            test_template.render({value: 'test succeeded'}).should.equal('the value is: test succeeded - with scope');
+        it("should load a simple template from a custom loader", function() {
+            twig({
+                method: 'custom', 
+                name: 'custom_loader_simple'
+            }).render({value: 'test succeeded'}).should.equal('the value is: test succeeded');
+        });
+        it("should load a template that includes another from a custom loader", function() {
+            twig({
+                method: 'custom', 
+                name: 'custom_loader_include'
+            }).render({value: 'test succeeded'}).should.equal('include others from the same loader method - the value is: test succeeded');
+        });
+        it("should load a template that extends another from a custom loader", function() {
+            twig({
+                method: 'custom', 
+                name: 'custom_loader_complex'
+            }).render({value: 'test succeeded'}).should.equal('This lets you extend other templates and include others from the same loader method - the value is: test succeeded');
         });
         it("should remove a registered loader", function() {
             Twig.extend(function(Twig) {

--- a/test/test.loaders.js
+++ b/test/test.loaders.js
@@ -1,0 +1,35 @@
+var Twig = Twig || require("../twig"),
+    twig = twig || Twig.twig;
+
+describe("Twig.js Loaders ->", function() {
+    // Encodings
+    describe("custom loader ->", function() {
+        it("should define a custom loader", function() {
+            Twig.extend(function(Twig) {
+                var obj = {
+                    test: 'with scope',
+                    loader: function(location, params, callback, error_callback) {
+                        params.data = 'the value is: {{ value }} - ' + this.test;
+                        var template = new Twig.Template(params);
+                        if (typeof callback === 'function') {
+                            callback(template);
+                        }
+                        return template;
+                    }
+                };
+                Twig.Templates.registerLoader('custom', obj.loader, obj);
+                Twig.Templates.loaders.should.have.property('custom');
+            });
+        });
+        it("should load a template from a custom loader", function() {
+            var test_template = twig({method: 'custom'});
+            test_template.render({value: 'test succeeded'}).should.equal('the value is: test succeeded - with scope');
+        });
+        it("should remove a registered loader", function() {
+            Twig.extend(function(Twig) {
+                Twig.Templates.unRegisterLoader('custom');
+                Twig.Templates.loaders.should.not.have.property('custom');
+            });
+        });
+    });
+});


### PR DESCRIPTION
This is an attempt to fulfill Issue #294, [Request] override template loading mechanism(s).

This PR introduces a way for users to extend Twig and implement their own custom template loaders.  It also allows you to override previously defined loaders.

For example, load a template from redis:

```
var Twig = require('twig'),
	redis = require('redis'),
	client = redis.createClient();

Twig.extend(function(Twig) {
	
	Twig.Templates.registerLoader('redis', function(location, params, callback, error_callback) {

		var precompiled = params.precompiled;

		if (typeof callback !== 'function') {
			throw new Twig.Error('The params.load callback is required for the redis loader method');
		}

		if (!params.async) {
			throw new Twig.Error('The "redis" loader method must be used asynchronously.');
		}

		client.get(location, function(err, data) {
			if (err) {
				if (typeof error_callback === 'function') {
					error_callback(err);
				}
				return;
			}

			if (precompiled) {
				params.data = JSON.parse(data);
			} else {
				params.data = data;
			}

			var template = new Twig.Template(params);
			callback(template);
		});

		return true;

	});

});
```

Fetch a template using the custom redis loader:

```
twig({
	method: 'redis', 
	name: 'my_template_name',
	load: function(template) {
		var output = template.render({data: 'here'});
	}
});
```

The business logic for 'fs' and 'ajax' loaders have been moved into their own files, twig.loader.fs.js and twig.loader.ajax.js, respectively.

Once you set the method for a template, all extends or includes spawning from that template should follow the same method.

Just as "path" and "url" are special to AJAX and FS methods, so is "name" special to custom methods.  However, custom methods also respect "id" if there is no name.