### PR TITLE
issue #293 - support block shortcuts

### DIFF
--- a/test/browser/test.block.js
+++ b/test/browser/test.block.js
@@ -114,4 +114,22 @@ describe("Twig.js Blocks ->", function() {
             })
         });
     });
+
+    describe("block shorthand ->", function() {
+        it("should render block content using shorthand syntax", function() {
+            twig({
+                data: '{% set prefix = "shorthand" %}{% block title (prefix ~ " - " ~ block_value)|title %}'
+            })
+            .render({block_value: 'test succeeded'})
+            .should.equal('Shorthand - Test Succeeded');
+        });
+        it("should overload blocks from an extended template using shorthand syntax", function() {
+            twig({
+                allowInlineIncludes: true,
+                data: '{% extends "child-extends" %}{% block title "New Title" %}{% block body "new body uses the " ~ base ~ " template" %}'
+            })
+            .render({ base: "template.twig" })
+            .should.equal( "New Title - new body uses the template.twig template" );
+        });
+    });
 });

--- a/test/test.block.js
+++ b/test/test.block.js
@@ -219,4 +219,22 @@ describe("Twig.js Blocks ->", function() {
         });
 
     });
+
+    describe("block shorthand ->", function() {
+        it("should render block content using shorthand syntax", function() {
+            twig({
+                data: '{% set prefix = "shorthand" %}{% block title (prefix ~ " - " ~ block_value)|title %}'
+            })
+            .render({block_value: 'test succeeded'})
+            .should.equal('Shorthand - Test Succeeded');
+        });
+        it("should overload blocks from an extended template using shorthand syntax", function() {
+            twig({
+                allowInlineIncludes: true,
+                data: '{% extends "child-extends" %}{% block title "New Title" %}{% block body "new body uses the " ~ base ~ " template" %}'
+            })
+            .render({ base: "template.twig" })
+            .should.equal( "New Title - new body uses the template.twig template" );
+        });
+    });
 });


### PR DESCRIPTION
Thought I would take a stab at this.  Let me know if there's a better way to do it.

This PR introduces block shortcuts (issue #293), as explained here: http://twig.sensiolabs.org/doc/tags/extends.html#block-shortcuts

Usage example:
```
{% block title page_title|title %}
```

Should be the same as:
```
{% block title %}
    {{ page_title|title }}
{% endblock %}
```