### PR TITLE
issue #281 - fix should.js in browser

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -3,12 +3,11 @@
   <meta charset="utf-8">
   <title>Mocha Tests</title>
   <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
-  <script src="lib/chai.js"></script>
+  <script src="../node_modules/should/should.js"></script>
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
   <script src="../node_modules/mocha/mocha.js"></script>
   <script src="../twig.js"></script>
   <script type="text/javascript">
-	chai.should();
 	mocha.setup('bdd')
   </script>
   <script src="test.core.js"></script>


### PR DESCRIPTION
This PR fixes the browser tests for should.js (issue #281).

As per the README at https://github.com/shouldjs/should.js, you just need to include "should.js" in the browser to get it working.  That means the NPM module needs to be installed first, by running `npm i`

I don't think we need Chai anymore, but I did not want to remove the lib in test/lib/chai.js.  All tests are passing now without it.