### PR TITLE
Support `undefined` and `null` values for the `in` operator

### DIFF
--- a/src/twig.expression.operator.js
+++ b/src/twig.expression.operator.js
@@ -17,10 +17,11 @@ var Twig = (function (Twig) {
     };
 
     var containment = function(a, b) {
-        if (b.indexOf !== undefined) {
+        if (b === undefined || b === null) {
+            return false;
+        } else if (b.indexOf !== undefined) {
             // String
             return a === b || a !== '' && b.indexOf(a) > -1;
-
         } else {
             var el;
             for (el in b) {

--- a/src/twig.expression.operator.js
+++ b/src/twig.expression.operator.js
@@ -18,7 +18,7 @@ var Twig = (function (Twig) {
 
     var containment = function(a, b) {
         if (b === undefined || b === null) {
-            return false;
+            return null;
         } else if (b.indexOf !== undefined) {
             // String
             return a === b || a !== '' && b.indexOf(a) > -1;

--- a/test/test.expressions.js
+++ b/test/test.expressions.js
@@ -289,6 +289,11 @@ describe("Twig.js Expressions ->", function() {
             test_template.render().should.equal(true.toString());
         });
 
+        it("should support undefined and null for the in operator", function() {
+            var test_template = twig({data: '{{ 0 in undefined }} {{ 0 in null }}'});
+            test_template.render().should.equal(' ');
+        });
+
         it("should support expressions as object keys", function() {
             var test_template;
             test_template = twig({data: '{% set a = {(foo): "value"} %}{{ a.bar }}'});


### PR DESCRIPTION
replaces #270 

- support for `{{ ... in undefined }}` and `{{ ... in null }}`, as with #270 
- corrected return value (null instead of false)
- add tests