### PR TITLE
updated to allow namespaces to be used with @

### DIFF
--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1270,11 +1270,14 @@ var Twig = (function (Twig) {
         if (typeof template === 'object' && typeof template.options === 'object') {
             namespaces = template.options.namespaces;
         }
-
-        if (typeof namespaces === 'object' && file.indexOf('::') > 0) {
+        
+        if (typeof namespaces === 'object' && (file.indexOf('::') > 0 || file.indexOf('@') >= 0)) {
             for (var k in namespaces){
                 if (namespaces.hasOwnProperty(k)) {
+
                     file = file.replace(k + '::', namespaces[k]);
+                    file = file.replace('@' + k, namespaces[k]);
+
                 }
             }
 

--- a/test/namespace.twig
+++ b/test/namespace.twig
@@ -1,0 +1,1 @@
+namespace

--- a/test/templates/namespace/namespace.twig
+++ b/test/templates/namespace/namespace.twig
@@ -1,0 +1,1 @@
+namespace

--- a/test/templates/namespace_::.twig
+++ b/test/templates/namespace_::.twig
@@ -1,0 +1,1 @@
+{% include "test::namespace.twig" %}

--- a/test/templates/namespace_@.twig
+++ b/test/templates/namespace_@.twig
@@ -1,0 +1,1 @@
+{% include "@test/namespace.twig" %}

--- a/test/test.namespace.js
+++ b/test/test.namespace.js
@@ -1,0 +1,38 @@
+var Twig = Twig || require("../twig"),
+    twig = twig || Twig.twig;
+
+describe("Twig.js Namespaces ->", function() {
+    it("should support namespaces defined with ::", function(done) {
+    	twig({
+			namespaces: { 'test': 'test/templates/namespace/' },
+			path: 'test/templates/namespace_::.twig',
+			load: function(template) {
+				// Render the template
+				template.render({
+				    test: "yes",
+				    flag: true
+				}).should.equal("namespace");
+
+				done();
+            }
+    	});        
+    });
+
+    it("should support namespaces defined with @", function(done) {
+    	twig({
+			namespaces: { 'test': 'test/templates/namespace/' },
+			path: 'test/templates/namespace_@.twig',
+			load: function(template) {
+				// Render the template
+				template.render({
+				    test: "yes",
+				    flag: true
+				}).should.equal("namespace");
+
+				done();
+            }
+    	});        
+    });
+
+
+});


### PR DESCRIPTION
Updated twig.js to allow the use if @ when using namespaces.

I made this change because of the documentation found [here ](http://twig.sensiolabs.org/doc/api.html#built-in-loaders).

> Namespaced templates can be accessed via the special @namespace_name/template_path notation