### PR TITLE
Support arrays in express views / template.base

### DIFF
--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1300,21 +1300,20 @@ var Twig = (function (Twig) {
             val;
 
 
-	if (typeof template.base === "object") {
-	  var fs = require("fs"),
-	      path = require("path"),
-	      temp = template.base.reverse(),
-	      sep = path.sep || sep_chr;
+	if (Array.isArray(template.base)) {
+	    var fs = require("fs"),
+		path = require("path"),
+		temp = template.base.reverse(),
+		sep = path.sep || sep_chr;
 
-	  for (var key in temp){
-	    try {
-	      fs.accessSync(temp[key] + sep + file, fs.F_OK);
-	      template.base = temp[key];
-	    } catch (e) {
+	    for (var key in temp) {
+		try {
+		    fs.accessSync(temp[key] + sep + file, fs.F_OK);
+		    base = temp[key] + ((temp[key].charAt(temp[key].length-1) === '/') ? '' : '/');
+		} catch (e) {
+		}
 	    }
-	  }
-	}
-	if (template.url) {
+	} else if (template.url) {
             if (typeof template.base !== 'undefined') {
                 base = template.base + ((template.base.charAt(template.base.length-1) === '/') ? '' : '/');
             } else {

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1299,7 +1299,19 @@ var Twig = (function (Twig) {
             new_path = [],
             val;
 
-        if (template.url) {
+
+	if (typeof template.base === "object") {
+	  var fs = require("fs"),
+	      path = "";
+
+	  for (var key in template.base){
+	    path = template.base[key] + '/' + file;
+
+	    if (!fs.accessSync(path, fs.F_OK)) {
+	      return path;
+	    };
+	  }
+	} else if (template.url) {
             if (typeof template.base !== 'undefined') {
                 base = template.base + ((template.base.charAt(template.base.length-1) === '/') ? '' : '/');
             } else {

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1303,7 +1303,7 @@ var Twig = (function (Twig) {
 	if (typeof template.base === "object") {
 	  var fs = require("fs"),
 	      path = require("path"),
-	      temp = template.base,
+	      temp = template.base.reverse(),
 	      sep = path.sep || sep_chr;
 
 	  for (var key in temp){

--- a/src/twig.core.js
+++ b/src/twig.core.js
@@ -1302,16 +1302,19 @@ var Twig = (function (Twig) {
 
 	if (typeof template.base === "object") {
 	  var fs = require("fs"),
-	      path = "";
+	      path = require("path"),
+	      temp = template.base,
+	      sep = path.sep || sep_chr;
 
-	  for (var key in template.base){
-	    path = template.base[key] + '/' + file;
-
-	    if (!fs.accessSync(path, fs.F_OK)) {
-	      return path;
-	    };
+	  for (var key in temp){
+	    try {
+	      fs.accessSync(temp[key] + sep + file, fs.F_OK);
+	      template.base = temp[key];
+	    } catch (e) {
+	    }
 	  }
-	} else if (template.url) {
+	}
+	if (template.url) {
             if (typeof template.base !== 'undefined') {
                 base = template.base + ((template.base.charAt(template.base.length-1) === '/') ? '' : '/');
             } else {


### PR DESCRIPTION
Hopefully this solution is simple enough to be a drop in fix for supporting multiple template locations.

Since the relative path function assumes a single string path, the goal is to check for the existence of the file on all of the paths, and then return the path to the reset of the function if that file exists.

The order of paths are flipped so that if the file is located in more than 1 location, the location earlier in the array will win out.

All the current tests pass, but I'm not sure how to approach adding a test for this functionality.