### PR TITLE
Browser tests for #320 resp. #328: Namespaces with :: and @

### DIFF
--- a/test/browser/test.namespace.js
+++ b/test/browser/test.namespace.js
@@ -1,0 +1,36 @@
+var Twig = Twig || require("../twig"),
+    twig = twig || Twig.twig;
+
+describe("Twig.js Namespaces ->", function() {
+    it("should support namespaces defined with ::", function(done) {
+	twig({
+			namespaces: { 'test': 'templates/namespaces/' },
+			href: 'templates/namespaces_::.twig',
+			load: function(template) {
+				// Render the template
+				template.render({
+				    test: "yes",
+				    flag: true
+				}).should.equal("namespaces");
+
+				done();
+            }
+    	});
+    });
+
+    it("should support namespaces defined with @", function(done) {
+	twig({
+			namespaces: { 'test': 'templates/namespaces/' },
+			href: 'templates/namespaces_@.twig',
+			load: function(template) {
+				// Render the template
+				template.render({
+				    test: "yes",
+				    flag: true
+				}).should.equal("namespaces");
+
+				done();
+            }
+    	});
+    });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -24,6 +24,7 @@
   <script src="browser/test.browser.js"></script>
   <script src="browser/test.block.js"></script>
   <script src="browser/test.macro.js"></script>
+  <script src="browser/test.namespace.js"></script>
   <script type="text/javascript">
     $(function () {
       mocha


### PR DESCRIPTION
#320 and #328 only includes tests for the filesystem loader; here are the tests for browsers.